### PR TITLE
Pre-compile Views Causing Errors

### DIFF
--- a/bb-prototype-website-razor.csproj
+++ b/bb-prototype-website-razor.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-	<PropertyGroup>
-		<MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
-	</PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BB.Prototype.Website.Razor.Framework" Version="1.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />


### PR DESCRIPTION
When publishing through Team City the precompiling of views was causing errors. This was removed on CR so should be reflected in the base project